### PR TITLE
chore: pre-commit upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,46 +1,65 @@
 fail_fast: false # such that all edits will run subsequently
 default_language_version:
+  # python: ~/.pyenv/versions/3.8.19/bin/python
   python: python3.8
-default_stages: [commit]
+default_stages: [pre-commit]
+ci:
+  autoupdate_schedule: quarterly  # low frequency to reduce maintenance noise
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: "v3.20.0"
+    rev: "v3.29.1"
     hooks:
       - id: commitizen
         stages: [commit-msg]
   # Fixes:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
+    rev: "v5.0.0"
     hooks:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.3.2"
+    rev: "v0.7.0"
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+  # - repo: https://github.com/pycqa/docformatter
+  #   rev: v1.7.5
+  #   hooks:
+  #     - id: docformatter
+  #       args: ["--in-place", "--config=./pyproject.toml"]
+  #       language: python
+  #       additional_dependencies: [tomli]
+  - repo: local
     hooks:
-      - id: docformatter
-        args: ["--in-place", "--config=./pyproject.toml"]
-        additional_dependencies: [tomli]
+    - id: docformatter
+      name: docformatter
+      description: Formats docstrings to follow PEP 257.
+      entry: python -Im docformatter
+      additional_dependencies:
+      - docformatter == 1.7.5
+      - tomli
+      args:
+      - --in-place
+      - --config=./pyproject.toml
+      language: python
+      types:
+      - python
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         files: (.*\.md)
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.12.0
+    rev: v2.14.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix]
         exclude: poetry.lock
   - repo: https://github.com/python-poetry/poetry
-    rev: "1.8.2"
+    rev: "1.8.0"
     hooks:
       - id: poetry-lock
         name: poetry-lock (lib-a)
@@ -76,7 +95,7 @@ repos:
         args: ["--no-update", "-C", "tests/fixtures/simple_a/lib-missing"]
   # Checks:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -89,12 +108,12 @@ repos:
       - id: check-yaml
       - id: debug-statements
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.12.0
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
         additional_dependencies: ["poetry~=1.7.1", "poetry-core~=1.8.1"]
   - repo: https://github.com/python-poetry/poetry
-    rev: "1.8.2"
+    rev: "1.8.0"
     hooks:
       - id: poetry-check


### PR DESCRIPTION
disabling github docformatter hook due to parse error on language: python_venv and using own inplace definition

also upgrade plugins