### PR TITLE
Avoid breaking requirements.txt syntax

### DIFF
--- a/poetry_plugin_mono_repo_deps/plugin.py
+++ b/poetry_plugin_mono_repo_deps/plugin.py
@@ -148,7 +148,7 @@ class MonoRepoDepsPlugin(ApplicationPlugin):
                         new = create_named_dependency(constraint, dep, package)
                         # new = Dependency(name, version or "*", extras=dep.extras)
                         io.write_line(
-                            f"Replacing path dependency {dep.to_pep_508()} in group "
+                            f"# Replacing path dependency {dep.to_pep_508()} in group "
                             f"{group.name} with {new.to_pep_508()}"
                         )
                         group.remove_dependency(name)


### PR DESCRIPTION
The presence of this log line makes the output of `poetry export` invalid for use by pip. For example, `poetry export --without-hashes | pip install -r /dev/stdin` will fail with a parse error. The leading hash lets `pip` treat the line as a comment.