### PR TITLE
test: fix test suite for poetry 2.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,12 @@ jobs:
       matrix:
         os: [Ubuntu, macOS, Windows]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        poetry-version: ["==1.7.0", "==1.7.1", "==1.8.0", "==1.8.1", "==1.8.2", "==1.8.3", "==1.8.4", "==1.8.5", "==2.0.0", ""]
+        poetry-version: ["==1.7.0", "==1.7.1", "==1.8.0", "==1.8.1", "==1.8.2", "==1.8.3", "==1.8.4", "==1.8.5", "==2.0.0", "==2.0.1", ""]
         exclude:
           - python-version: "3.8"
             poetry-version: "==2.0.0"
+          - python-version: "3.8"
+            poetry-version: "==2.0.1"
           - python-version: "3.8"
             poetry-version: ""
         include:

--- a/tests/test_commands_e2e.py
+++ b/tests/test_commands_e2e.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import zipfile
 from pathlib import Path
 from tarfile import TarFile
@@ -163,4 +164,14 @@ def test_outside_project_search(tmp_path: Path) -> None:
     args = ["poetry", "search", "requests"]
     _out_value, err_value = run_test_app(args)
     _logger.info(_out_value)
-    assert err_value == ""
+    if POETRY_VERSION >= 2:
+        # since poetry 2.0.1 running poetry search outside project always prints error
+        # we assume we didn't cause a different error if we get that error
+        has_runtime_error = (
+            re.search(r"RuntimeError\s+Poetry could not find a pyproject.toml file in .* or its parents", err_value)
+            is not None
+        )
+        assert err_value == "" or has_runtime_error
+
+    else:
+        assert err_value == ""


### PR DESCRIPTION
which now raises RuntimeError when running on folder without `pyproject.toml`

Includes 2.0.1 explicitly in the test matrix.